### PR TITLE
Use `git describe` to derive application version number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Fetch all history for all tags and branches
       - name: Set up JDK 15
         uses: actions/setup-java@v2
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -38,12 +38,29 @@ plugins {
     id 'org.unbroken-dome.xjc' version '2.0.0'
 
     id 'checkstyle'
+
+    // https://github.com/qoomon/gradle-git-versioning-plugin
+    id 'me.qoomon.git-versioning' version '6.3.6'
 }
 
 apply plugin: 'io.github.fvarrui.javapackager.plugin'
 apply plugin: 'com.gitlab.svg2ico'
 
-version '2.4.0'
+gitVersioning.apply {
+    refs {
+        considerTagsOnBranches = true
+        tag('v(?<version>.*)') {
+            version = '${ref.version}'
+        }
+        branch('.+') {
+            version = '${describe.tag.version}-${describe.distance}'
+        }
+    }
+
+    rev {
+        version = '${commit}'
+    }
+}
 
 sourceCompatibility = 8
 targetCompatibility = 15


### PR DESCRIPTION
Generate application version from [SCM](https://en.wikipedia.org/wiki/Version_control) ([`git describe`](https://git-scm.com/docs/git-describe)) using [Gradle Git Versioning Plugin](https://github.com/qoomon/gradle-git-versioning-plugin).