### PR TITLE
Use java.io.File instead custom implementations.

### DIFF
--- a/src/main/java/listfix/io/Constants.java
+++ b/src/main/java/listfix/io/Constants.java
@@ -56,7 +56,7 @@ public class Constants
   public static final String INVALID_WINDOWS_FILENAME_CHARACTERS = "*|\\/:\"<>?";
 
   /**
-   * Boolean specifying if the current OS's file system is case sensitive.
+   * Boolean specifying if the current OS's file system is case-sensitive.
    */
   public static final boolean FILE_SYSTEM_IS_CASE_SENSITIVE = File.separatorChar == '/';
 }

--- a/src/main/java/listfix/io/DirectoryScanner.java
+++ b/src/main/java/listfix/io/DirectoryScanner.java
@@ -63,44 +63,30 @@ public class DirectoryScanner
 
       File mediaDir = new File(baseDir);
       String[] entryList = mediaDir.list();
-      List<String> fileList = new ArrayList<>();
-      List<String> dirList = new ArrayList<>();
-      StringBuilder s = new StringBuilder();
+      Set<String> fileList = new TreeSet<>();
+      Set<String> dirList = new TreeSet<>();
 
       if (entryList != null)
       {
         File tempFile;
         for (String entryList1 : entryList)
         {
-          s.append(baseDir);
-          if (!baseDir.endsWith(Constants.FS))
-          {
-            s.append(Constants.FS);
-          }
-          s.append(entryList1);
-          tempFile = new File(s.toString());
+          tempFile = new File(baseDir, entryList1);
           if (tempFile.isDirectory())
           {
-            dirList.add(s.toString());
+            dirList.add(tempFile.getPath());
           }
           else
           {
             if (FileUtils.isMediaFile(tempFile))
             {
-              fileList.add(s.toString());
+              fileList.add(tempFile.getPath());
             }
           }
-          s.setLength(0);
         }
       }
 
-      Collections.sort(fileList);
-      Collections.sort(dirList);
-
-      for (String file : fileList)
-      {
-        thisFileList.add(file);
-      }
+      thisFileList.addAll(fileList);
 
       for (String dir : dirList)
       {
@@ -110,10 +96,6 @@ public class DirectoryScanner
 
       fileList.clear();
       dirList.clear();
-    }
-    else
-    {
-      return;
     }
   }
 

--- a/src/main/java/listfix/io/FileUtils.java
+++ b/src/main/java/listfix/io/FileUtils.java
@@ -24,22 +24,20 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.StringTokenizer;
-import listfix.controller.GUIDriver;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
- *
  * @author jcaron
  */
 public class FileUtils
 {
-  /**
-   *
-   * @param file
-   * @return
-   */
+  private static final Set<String> mediaExtension = Stream.of("mp3", "wma", "flac", "ogg", "wav", "midi", "cda", "mpg", "mpeg", "m2v", "avi", "m4v", "flv", "mid", "mp2", "mp1", "aac", "asx", "m4a", "mp4", "m4v", "nsv", "aiff", "au", "wmv", "asf", "mpc")
+    .collect(Collectors.toCollection(HashSet::new));
+
   public static File findDeepestPathToExist(File file)
   {
     if (file == null || file.exists())
@@ -49,28 +47,19 @@ public class FileUtils
     return findDeepestPathToExist(file.getParentFile());
   }
 
-  /**
-   *
-   * @param file
-   * @return
-   */
   public static boolean isMediaFile(File file)
   {
-    String input = file.getName().toLowerCase();
-    return (input.endsWith(".mp3") || input.endsWith(".wma")
-      || input.endsWith(".flac") || input.endsWith(".ogg")
-      || input.endsWith(".wav")  || input.endsWith(".midi")
-      || input.endsWith(".cda")  || input.endsWith(".mpg")
-      || input.endsWith(".mpeg") || input.endsWith(".m2v")
-      || input.endsWith(".avi")  || input.endsWith(".m4v")
-      || input.endsWith(".flv")  || input.endsWith(".mid")
-      || input.endsWith(".mp2")  || input.endsWith(".mp1")
-      || input.endsWith(".aac")  || input.endsWith(".asx")
-      || input.endsWith(".m4a")  || input.endsWith(".mp4")
-      || input.endsWith(".m4v")  || input.endsWith(".nsv")
-      || input.endsWith(".aiff") || input.endsWith(".au")
-      || input.endsWith(".wmv")  || input.endsWith(".asf")
-      || input.endsWith(".mpc"));
+    return isMediaFile(file.getName());
+  }
+
+  public static boolean isMediaFile(String filename)
+  {
+    String extension = getFileExtension(filename);
+    if (extension != null)
+    {
+      return mediaExtension.contains(extension.toLowerCase());
+    }
+    return false;
   }
 
   public static boolean isURL(String trackText)
@@ -93,110 +82,18 @@ public class FileUtils
     }
   }
 
-  /**
-   *
-   * @param file
-   * @param relativeTo
-   * @return
-   */
   public static String getRelativePath(File file, File relativeTo)
   {
     try
     {
-      UNCFile unc1 = new UNCFile(file);
-      UNCFile unc2 = new UNCFile(relativeTo);
-      StringTokenizer fileTizer;
-      StringTokenizer relativeToTizer;
-      if (unc1.onNetworkDrive())
-      {
-        fileTizer = new StringTokenizer(unc1.getUNCPath(), Constants.FS);
-      }
-      else
-      {
-        fileTizer = new StringTokenizer(file.getAbsolutePath(), Constants.FS);
-      }
-      if (unc2.onNetworkDrive())
-      {
-        relativeToTizer = new StringTokenizer(unc2.getUNCPath(), Constants.FS);
-      }
-      else
-      {
-        relativeToTizer = new StringTokenizer(relativeTo.getAbsolutePath(), Constants.FS);
-      }
-      List<String> fileTokens = new ArrayList<>();
-      List<String> relativeToTokens = new ArrayList<>();
-      while (fileTizer.hasMoreTokens())
-      {
-        fileTokens.add(fileTizer.nextToken());
-      }
-      while (relativeToTizer.hasMoreTokens())
-      {
-        relativeToTokens.add(relativeToTizer.nextToken());
-      }
-
-      // throw away last token from each, don't need the file names for path calculation.
-      String fileName = "";
-      if (file.isFile())
-      {
-        fileName = fileTokens.remove(fileTokens.size() - 1);
-      }
-
-      // relativeTo is the playlist we'll be writing to, we need to remove the last token regardless...
-      relativeToTokens.remove(relativeToTokens.size() - 1);
-
-      int maxSize = Math.min(fileTokens.size(), relativeToTokens.size());
-      boolean tokenMatch = false;
-      int i = 0;
-      while (i < maxSize)
-      {
-        if (GUIDriver.FILE_SYSTEM_IS_CASE_SENSITIVE ? fileTokens.get(i).equals(relativeToTokens.get(i)) : fileTokens.get(i).equalsIgnoreCase(relativeToTokens.get(i)))
-        {
-          tokenMatch = true;
-          fileTokens.remove(i);
-          relativeToTokens.remove(i);
-          i--;
-          maxSize--;
-        }
-        else if (!tokenMatch)
-        {
-          // files can not be made relative to one another.
-          return file.getAbsolutePath();
-        }
-        else
-        {
-          break;
-        }
-        i++;
-      }
-
-      StringBuilder resultBuffer = new StringBuilder();
-      for (String relativeToToken : relativeToTokens)
-      {
-        resultBuffer.append("..").append(Constants.FS);
-      }
-
-      for (String fileToken : fileTokens)
-      {
-        resultBuffer.append(fileToken).append(Constants.FS);
-      }
-
-      resultBuffer.append(fileName);
-
-      return resultBuffer.toString();
+      return Path.of(UNCFile.from(relativeTo).getUNCPath()).relativize(file.toPath()).toString();
     }
-    catch (Exception e)
+    catch (IllegalArgumentException exception)
     {
-      // not logging anything here as this seems to be a common fallback...
-      return file.getAbsolutePath();
+      throw exception;
     }
   }
 
-  /**
-   *
-   * @param input
-   * @param replacement
-   * @return
-   */
   public static String replaceInvalidWindowsFileSystemCharsWithChar(String input, char replacement)
   {
     StringBuilder result = new StringBuilder();
@@ -215,7 +112,6 @@ public class FileUtils
   }
 
   /**
-   *
    * @param dir
    */
   public static void deleteDirectory(File dir)
@@ -244,12 +140,14 @@ public class FileUtils
   }
 
   /**
+   * Extract the extension from the provided filename
    *
-   * @param nodeFile
-   * @return
+   * @param filename Filename
+   * @return extension without leading dot, e.g.: "mp3"
    */
-  public static String GetExtension(TreeNodeFile nodeFile)
+  public static String getFileExtension(String filename)
   {
-    return nodeFile.getName().substring(nodeFile.getName().lastIndexOf("."));
+    int index = filename.lastIndexOf(".");
+    return index == -1 ? null : filename.substring(filename.lastIndexOf(".") + 1);
   }
 }

--- a/src/main/java/listfix/io/UNCFile.java
+++ b/src/main/java/listfix/io/UNCFile.java
@@ -149,4 +149,8 @@ public class UNCFile extends File
   {
     return driveLister.onNetworkDrive(this.getAbsolutePath());
   }
+
+  public static UNCFile from(File file) {
+    return new UNCFile(file);
+  }
 }

--- a/src/main/java/listfix/io/readers/playlists/M3UReader.java
+++ b/src/main/java/listfix/io/readers/playlists/M3UReader.java
@@ -281,7 +281,7 @@ public class M3UReader extends PlaylistReader
     }
     else if (OperatingSystem.isLinux()) // Linux Specific Setup
     {
-      if (!L2.startsWith("\\\\") && !L2.startsWith(".") && !L2.startsWith(Constants.FS))
+      if (!L2.startsWith("\\\\") && !L2.startsWith(".") && !L2.startsWith("/"))
       {
         // Need to append ./ on relative entries to load them properly
         path.append("./");

--- a/src/main/java/listfix/model/playlists/Playlist.java
+++ b/src/main/java/listfix/model/playlists/Playlist.java
@@ -27,7 +27,6 @@ import java.util.*;
 
 import listfix.config.IMediaLibrary;
 
-import listfix.io.Constants;
 import listfix.io.FileLauncher;
 import listfix.io.UNCFile;
 import listfix.io.readers.playlists.IPlaylistReader;
@@ -209,7 +208,7 @@ public class Playlist
           fileToCopy = tempEntry.getAbsoluteFile();
           if (tempEntry.isFound()) // && fileToCopy.exists())
           {
-            dest = new File(destinationDirectory.getPath() + Constants.FS + tempEntry.getFileName());
+            dest = new File(destinationDirectory.getPath(), tempEntry.getFileName());
             try
             {
               FileCopier.copy(fileToCopy, dest);
@@ -777,7 +776,7 @@ public class Playlist
 
   /**
    * @param mediaLibrary Media library used to reference existing media files
-   * @param observer Progress observer
+   * @param observer     Progress observer
    * @return
    */
   public List<Integer> repair(IMediaLibrary mediaLibrary, IProgressObserver observer)
@@ -824,12 +823,14 @@ public class Playlist
    * @param dirLists Media library used for repair
    * @param observer Progress observer
    */
-  public void batchRepair(IMediaLibrary dirLists, IProgressObserver<String> observer) {
+  public void batchRepair(IMediaLibrary dirLists, IProgressObserver<String> observer)
+  {
     this.batchRepair(dirLists.getNestedMediaFiles(), dirLists, observer);
   }
 
   /**
    * Similar to repair, but doesn't return repaired row information
+   *
    * @param fileList Media library used for repair
    * @param observer Progress observer
    */

--- a/src/main/java/listfix/view/GUIScreen.java
+++ b/src/main/java/listfix/view/GUIScreen.java
@@ -1606,7 +1606,7 @@ public final class GUIScreen extends JFrame implements DropTargetListener
           curNode = (DefaultMutableTreeNode) selPath.getLastPathComponent();
           nodeFile = (TreeNodeFile) curNode.getUserObject();
           String str = curNode.toString();
-          String reply = JOptionPane.showInputDialog(this, new JTransparentTextArea("Rename " + str), FileUtils.GetExtension(nodeFile));
+          String reply = JOptionPane.showInputDialog(this, new JTransparentTextArea("Rename " + str), "." + FileUtils.getFileExtension(nodeFile.getName()));
           if (reply != null && !"".equals(reply))
           {
             TreeNodeFile destFile = new TreeNodeFile(nodeFile.getParent() + Constants.FS + reply);

--- a/src/test/java/listfix/io/FileUtilsTests.java
+++ b/src/test/java/listfix/io/FileUtilsTests.java
@@ -1,0 +1,23 @@
+package listfix.io;
+
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+public class FileUtilsTests
+{
+
+  @Test
+  public void getFileExtension() {
+    assertEquals("mp3", FileUtils.getFileExtension("audio.mp3"));
+    assertNull(FileUtils.getFileExtension("audio"));
+  }
+
+  @Test
+  public void isMediaFile() {
+    assertTrue(FileUtils.isMediaFile("audio.mp3"), "audio.mp3");
+    assertTrue(FileUtils.isMediaFile("audio.MP3"), "audio.MP3");
+    assertTrue(FileUtils.isMediaFile("audio.mP3"), "audio.mP3");
+    assertFalse(FileUtils.isMediaFile("notepad.exe"), "notepad.exe");
+    assertFalse(FileUtils.isMediaFile("audio"), "audio");
+  }
+}


### PR DESCRIPTION
- Use `java.io.File` instead custom implementations
- Remove some empty comments.
- Remove some duplicate code.