### PR TITLE
Fix Exception thrown opening folder in "Playlist Directory"

### DIFF
--- a/src/main/java/listfix/comparators/DirectoryThenFileThenAlphabeticalFileComparator.java
+++ b/src/main/java/listfix/comparators/DirectoryThenFileThenAlphabeticalFileComparator.java
@@ -22,27 +22,12 @@ package listfix.comparators;
 
 import java.io.File;
 
-/*
-============================================================================
-= Author:   Jeremy Caron
-= File:     DirectoryThenFileThenAlphabeticalFileComparator.java
-= Purpose:  Sorts directories ahead of files, and then sorts files
-=      alphabetically (ignoring case).
-============================================================================
- */
-
 /**
- *
- * @author jcaron
+ * Sorts directories ahead of files, and then sorts files alphabetically (ignoring case).
  */
 public class DirectoryThenFileThenAlphabeticalFileComparator implements java.util.Comparator<File>
 {
-  /**
-   *
-   * @param a
-   * @param b
-   * @return
-   */
+
   @Override
   public int compare(File a, File b)
   {

--- a/src/main/java/listfix/util/FileTypeSearch.java
+++ b/src/main/java/listfix/util/FileTypeSearch.java
@@ -1,23 +1,3 @@
-/*
- * listFix() - Fix Broken Playlists!
- * Copyright (C) 2001-2014 Jeremy Caron
- *
- * This file is part of listFix().
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, please see http://www.gnu.org/licenses/
- */
-
 package listfix.util;
 
 import listfix.comparators.DirectoryThenFileThenAlphabeticalFileComparator;
@@ -29,14 +9,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-/**
- *
- * @author jcaron
- */
 public class FileTypeSearch
 {
   /**
-   *
    * @param directoryToSearch
    * @param filter
    * @return
@@ -45,32 +20,27 @@ public class FileTypeSearch
   {
     if (directoryToSearch.exists())
     {
-      List<File> ol = new ArrayList<>();
       File[] inodes = directoryToSearch.listFiles(filter);
 
       if (inodes != null && inodes.length > 0)
       {
-                ol.addAll(Arrays.asList(inodes));
-        Collections.sort(ol, new DirectoryThenFileThenAlphabeticalFileComparator());
-        File f;
+        List<File> ol = new ArrayList<>(Arrays.asList(inodes));
+        ol.sort(new DirectoryThenFileThenAlphabeticalFileComparator());
         List<File> files = new ArrayList<>();
-        for (File ol1 : ol)
+        for (File file : ol)
         {
-          f = ol1;
-          if (f.isDirectory())
+          if (file.isDirectory())
           {
-            files.addAll(findFiles(f, filter));
+            files.addAll(findFiles(file, filter));
           }
           else
           {
-            files.add(f);
+            files.add(file);
           }
         }
-
         return files;
       }
-      return null;
     }
-    return null;
+    return Collections.emptyList();
   }
 }

--- a/src/main/java/listfix/view/GUIScreen.java
+++ b/src/main/java/listfix/view/GUIScreen.java
@@ -1447,7 +1447,7 @@ public final class GUIScreen extends JFrame implements DropTargetListener
   private void openPlaylistFoldersFromPlaylistTree()
   {
     this.getSelectedFilesFromTreePlaylists().stream()
-      .map(File :: getParentFile)
+      .map(file -> file.isDirectory() ? file : file.getParentFile())
       .filter(Objects :: nonNull)
       .distinct()
       .forEach(this :: openFolderInExplorerPerformed);


### PR DESCRIPTION
In the "Playlist Directory"
1. Fix Exception thrown opening folder via the context menu
2. When opening the file location (Explorer), opens the actual directory location instead of the parent directory location.

Resolves: #75 