### PR TITLE
Disable overriding `TabComponent`

### DIFF
--- a/src/main/java/listfix/swing/JDocumentTabbedPane.java
+++ b/src/main/java/listfix/swing/JDocumentTabbedPane.java
@@ -114,8 +114,8 @@ public class JDocumentTabbedPane extends JTabbedPane
     int index = super.getTabCount();
     this.addTab(document.getTitle(), document.getIcon(), document, document.getPath().toString());
 
-    JPanel tabComponent = new JButtonTabComponent(this, document.getIcon());
-    this.setTabComponentAt(index, tabComponent);
+//    JPanel tabComponent = new JButtonTabComponent(this, document.getIcon());
+//    this.setTabComponentAt(index, tabComponent);
   }
 
   public boolean renameDocument(String oldName, String newName)

--- a/src/main/java/listfix/swing/JDocumentTabbedPane.java
+++ b/src/main/java/listfix/swing/JDocumentTabbedPane.java
@@ -114,8 +114,9 @@ public class JDocumentTabbedPane extends JTabbedPane
     int index = super.getTabCount();
     this.addTab(document.getTitle(), document.getIcon(), document, document.getPath().toString());
 
-//    JPanel tabComponent = new JButtonTabComponent(this, document.getIcon());
-//    this.setTabComponentAt(index, tabComponent);
+    JPanel tabComponent = new JButtonTabComponent(this, document.getIcon());
+    this.setTabComponentAt(index, tabComponent);
+    this.validate();
   }
 
   public boolean renameDocument(String oldName, String newName)


### PR DESCRIPTION
Disabling overriding the tab component, to see if that has an effect on the _double printed tab pane headings_ reported in issue #55.