### PR TITLE
Drop `com.google.guava:guava` dependency, resolving vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 buildscript {
     repositories {
-        mavenLocal()
         mavenCentral()
         maven { url 'https://plugins.gradle.org/m2/' }
     }
@@ -107,9 +106,6 @@ dependencies {
     // https://mvnrepository.com/artifact/com.jgoodies/jgoodies-looks
     implementation 'com.jgoodies:jgoodies-looks:2.7.0'
 
-    // This dependency is used by the application.
-    implementation 'com.google.guava:guava:31.1-jre'
-
     // https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
@@ -179,7 +175,7 @@ task fatJar(type: Jar) {
     setDuplicatesStrategy(DuplicatesStrategy.WARN)
     archiveBaseName = 'listFix'
     archiveClassifier = 'all'
-    from { configurations.compileClasspath.filter { it.exists() }.collect { it.isDirectory() ? it : zipTree(it) } }
+    from { configurations.runtimeClasspath.filter { it.exists() }.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
 }
 

--- a/src/main/java/listfix/io/playlists/PlaylistWriter.java
+++ b/src/main/java/listfix/io/playlists/PlaylistWriter.java
@@ -9,7 +9,6 @@ import listfix.model.playlists.PlaylistEntry;
 import listfix.util.OperatingSystem;
 import listfix.view.support.ProgressAdapter;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -83,7 +82,7 @@ public abstract class PlaylistWriter<C> implements IPlaylistWriter
    * @throws Exception If the playlist failed to save
    */
   @Override
-  public void save(Playlist playlist, boolean saveRelative, @Nullable ProgressAdapter<String> adapter) throws Exception
+  public void save(Playlist playlist, boolean saveRelative, ProgressAdapter<String> adapter) throws Exception
   {
     if (adapter == null)
     {

--- a/src/main/java/listfix/model/playlists/PlaylistEntry.java
+++ b/src/main/java/listfix/model/playlists/PlaylistEntry.java
@@ -1,6 +1,5 @@
 package listfix.model.playlists;
 
-import com.google.common.base.Splitter;
 import listfix.comparators.MatchedPlaylistEntryComparator;
 import listfix.io.IPlaylistOptions;
 import listfix.model.enums.PlaylistEntryStatus;
@@ -221,25 +220,25 @@ public abstract class PlaylistEntry implements Cloneable
       extra = extra.replaceFirst("#EXTINF:", "");
       if (extra.contains(","))
       {
-        List<String> split = Splitter.on(',').splitToList(extra);
-        if (split.size() > 1)
+        String[] split = extra.split("'");
+        if (split.length > 1)
         {
           try
           {
             // extra info comes from M3Us, so this comes in a seconds
             // and needs conversion to milliseconds.
-            _length = Long.parseLong(split.get(0)) * 1000L;
+            _length = Long.parseLong(split[0]) * 1000L;
           }
           catch (Exception e)
           {
             // ignore and move on...
           }
-          _title = split.get(1);
+          _title = split[1];
         }
-        else if (split.size() == 1)
+        else if (split.length == 1)
         {
           // assume it's a _title?
-          _title = split.get(0);
+          _title = split[0];
         }
       }
       else

--- a/src/main/java/listfix/view/controls/ClosestMatchesSearchScrollableResultsPanel.java
+++ b/src/main/java/listfix/view/controls/ClosestMatchesSearchScrollableResultsPanel.java
@@ -7,7 +7,6 @@ import listfix.view.support.ZebraJTable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.annotation.Nonnull;
 import javax.swing.*;
 import javax.swing.plaf.basic.BasicComboBoxRenderer;
 import javax.swing.table.*;
@@ -130,7 +129,7 @@ public class ClosestMatchesSearchScrollableResultsPanel extends JPanel
     return new ZebraJTable()
     {
       @Override
-      public String getToolTipText(@Nonnull MouseEvent event)
+      public String getToolTipText(MouseEvent event)
       {
         Point point = event.getPoint();
         int rawRowIx = rowAtPoint(point);


### PR DESCRIPTION
Resolving [[sonatype-2020-0926] CWE-379: Creation of Temporary File in Directory with Incorrect Permissions](https://ossindex.sonatype.org/vulnerability/sonatype-2020-0926)