### PR TITLE
CI: upload fat-jar artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,10 @@ jobs:
           path: build/test-results/test/*.xml
           reporter: java-junit
           fail-on-error: true
+      - name: Build fatJar
+        run: ./gradlew :fatJar
+      - name: Upload fatJar artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: fatJar
+          path: build/libs/listFix-*-all.jar


### PR DESCRIPTION
Build the FAT-Jar (executable Java) in the pipeline, and upload that as an artifact.
Unfortunately GitHub does not provide a user friendly way to access the artifact:

![image](https://user-images.githubusercontent.com/23255260/230638282-b616b95a-94ff-4b52-bd92-4823c0c58e6a.png)
![image](https://user-images.githubusercontent.com/23255260/230638473-7d9cf9c1-40ed-42bb-a2cf-5dbcab72525a.png)
![image](https://user-images.githubusercontent.com/23255260/230638741-6725f85d-e9db-4663-b21c-af7d53633cd5.png)
![image](https://user-images.githubusercontent.com/23255260/230638977-ab078dc5-71eb-4465-b5e2-58a3611714c5.png)
