### PR TITLE
Support Java 9 Platform Module System (JPMS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,10 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: Build
         run: ./gradlew :build
-      - name: Assemble
-        run: ./gradlew :assemble
-      - name: Upload compiled Windows distribution
+      - name: jlinkZip
+        run: ./gradlew :jlinkZip
+      - name: Upload Windows jlink image
         uses: actions/upload-artifact@v3
         with:
           name: listFix-windows
-          path: build/distributions/listFix-*.zip
+          path: build/image.zip

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ plugins {
 
     // https://github.com/qoomon/gradle-git-versioning-plugin
     id 'me.qoomon.git-versioning' version '6.4.2'
+
+    id 'org.beryx.jlink' version '2.26.0'
+    id 'org.gradlex.extra-java-module-info' version '1.3'
 }
 
 apply plugin: 'io.github.fvarrui.javapackager.plugin'
@@ -85,14 +88,10 @@ repositories {
 dependencies {
 
     // Provides christophedelory.playlist.*
-    implementation 'io.github.borewit:lizzy:2.0.0'
+    implementation 'io.github.borewit:lizzy:3.0.0'
 
     // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core
     implementation 'org.apache.logging.log4j:log4j-core:2.20.0'
-
-    // Apache SLF4J to Log4j2 Adapter (bridge)
-    // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-slf4j2-impl
-    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j2-impl:2.20.0'
 
     implementation 'jakarta.activation:jakarta.activation-api:2.1.1';
 
@@ -106,10 +105,6 @@ dependencies {
     // https://mvnrepository.com/artifact/commons-io/commons-io
     implementation 'commons-io:commons-io:2.11.0'
 
-    // Used to read the version number from the manifest
-    // https://mvnrepository.com/artifact/com.jcabi/jcabi-manifests/1.2.1
-    implementation 'com.jcabi:jcabi-manifests:1.2.1'
-
     // Provide JFontChooser
     implementation 'com.rover12421.opensource:JFontChooser:1.0.5-3'
 
@@ -121,6 +116,7 @@ dependencies {
 }
 
 application {
+    mainModule = 'listFix.app'
     // Define the main class for the application.
     mainClass = project.mainClassName
 }
@@ -128,6 +124,31 @@ application {
 jar {
     manifest {
         attributes(manifestAttributes)
+    }
+}
+
+// Convert legacy dependency to named Java module
+extraJavaModuleInfo {
+    module('com.rover12421.opensource:JFontChooser', 'say.swing.JFontChooser') {
+        requires('java.desktop');
+        exports('say.swing')
+    }
+    module('org.objenesis:objenesis', 'org.objenesis') {
+        exports('org.objenesis')
+    }
+    module('org.mockito:mockito-core', 'org.mockito.core') {
+        exports('org.mockito.verification')
+    }
+    module('com.jcabi:jcabi-log', 'com.jcabi.log') {
+        exports('com.jcabi.log')
+    }
+    module('com.jcabi:jcabi-manifests', 'com.jcabi.manifests') {
+        //requires('com.jcabi.log')
+        exports('com.jcabi.manifests')
+    }
+    module('com.googlecode.plist:dd-plist', 'dd.plist') {
+        exports('com.dd.plist')
+        requires('java.xml')
     }
 }
 
@@ -148,6 +169,16 @@ sourceSets {
             srcDirs = ['src/main/resources', generatedResources]
         }
     }
+}
+
+jlink {
+    options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages']
+    launcher{
+        name = 'listfix'
+        noConsole = false
+        jvmArgs = ['-Dlog4j.configurationFile=./log4j2.xml']
+    }
+    forceMerge 'jackson', 'log4j', 'log4j-core', 'slf4j', 'com.jcabi.log'
 }
 
 task fatJar(type: Jar) {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -20,6 +20,11 @@
 
   <module name="FileTabCharacter"/>
 
+  <!-- Ignore module-info.java -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
+
   <module name="TreeWalker">
     <module name="RegexpSinglelineJava">
       <property name="format" value="\s+$"/>

--- a/src/main/java/listfix/view/GUIScreen.java
+++ b/src/main/java/listfix/view/GUIScreen.java
@@ -1,6 +1,5 @@
 package listfix.view;
 
-import com.jcabi.manifests.Manifests;
 import io.github.borewit.lizzy.playlist.PlaylistFormat;
 import listfix.config.*;
 import listfix.controller.ListFixController;
@@ -49,6 +48,8 @@ import java.util.List;
 import java.util.*;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 
 public final class GUIScreen extends JFrame implements IListFixGui
@@ -58,15 +59,14 @@ public final class GUIScreen extends JFrame implements IListFixGui
   private final FolderChooser _jMediaDirChooser = new FolderChooser();
   private final List<Playlist> _openPlaylists = new ArrayList<>();
   private final Image applicationIcon = this.getImageIcon("icon.png").getImage();
-  private final listfix.view.support.SplashScreen splashScreen = new listfix.view.support.SplashScreen("images/listfixSplashScreen.png");
-
+  private final listfix.view.support.SplashScreen splashScreen = new listfix.view.support.SplashScreen(this.getImageIcon("listfixSplashScreen.png"));
   private ListFixController _listFixController = null;
   private Playlist _currentPlaylist;
   private IPlaylistModifiedListener _playlistListener;
 
   private static final Logger _logger = LogManager.getLogger(GUIScreen.class);
 
-  private static final String applicationVersion = Manifests.read("Implementation-Version");
+  private static final String applicationVersion = getBuildNumber();
 
   private static final int keyEventRenameFile = KeyEvent.VK_F2;
 
@@ -90,6 +90,20 @@ public final class GUIScreen extends JFrame implements IListFixGui
     initComponents();
 
     postInitComponents();
+  }
+
+  public static String getBuildNumber() {
+    URL url = GUIScreen.class.getClassLoader().getResource("META-INF/MANIFEST.MF");
+    try
+    {
+      Manifest manifest = new Manifest(url.openStream());
+      Attributes mainAttributes = manifest.getMainAttributes();
+      return mainAttributes.getValue("Implementation-Version");
+    }
+    catch (IOException e)
+    {
+      throw new RuntimeException(e);
+    }
   }
 
   /**

--- a/src/main/java/listfix/view/support/SplashScreen.java
+++ b/src/main/java/listfix/view/support/SplashScreen.java
@@ -25,11 +25,8 @@ public class SplashScreen extends JFrame
 {
   private final JLabel statusBar;
 
-  public SplashScreen(String imageResourcePath)
+  public SplashScreen(ImageIcon image)
   {
-    ClassLoader cl = this.getClass().getClassLoader();
-    ImageIcon image = new ImageIcon(cl.getResource(imageResourcePath));
-
     getContentPane().setLayout(new BorderLayout());
     getContentPane().add(new JLabel(image));
 

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,13 @@
+module listFix.app {
+  requires com.fasterxml.jackson.databind;
+  requires org.apache.logging.log4j;
+  requires java.desktop;
+  requires io.github.borewit.lizzy;
+  requires org.apache.commons.io;
+  requires say.swing.JFontChooser;
+
+  opens listfix.json;
+
+  uses io.github.borewit.lizzy.playlist.SpecificPlaylistProvider;
+  uses org.apache.logging.log4j.spi.Provider;
+}


### PR DESCRIPTION
Changes:
1. Support [Java 9 Platform Module System (JPMS)](https://en.wikipedia.org/wiki/Java_Platform_Module_System)
2. Use [jlink](https://docs.oracle.com/en/java/javase/11/tools/jlink.html) to build application.
3. Uploads Windows runtime image as an artifact