### PR TITLE
Build Windows installers with jpackage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,15 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: Build
         run: ./gradlew :build
-      - name: jlinkZip
-        run: ./gradlew :jlinkZip
-      - name: Upload Windows jlink image
+      - name: Build Windows installers
+        run: ./gradlew :jpackage
+      - name: Upload Windows msi
         uses: actions/upload-artifact@v3
         with:
-          name: listFix-windows
-          path: build/image.zip
+          name: listFix-windows-msi
+          path: build/jpackage/listfix-*.msi
+      - name: Upload Windows exe
+        uses: actions/upload-artifact@v3
+        with:
+          name: listFix-windows-exe
+          path: build/jpackage/listFix()-*.exe

--- a/README.md
+++ b/README.md
@@ -47,12 +47,6 @@ In project folder, run:
 gradlew build
 ```
 
-### Build Windows executable
-In project folder, run:
-```shell
-gradlew createExe
-```
-
 ### Run application
 In project folder, run:
 ```shell
@@ -62,7 +56,7 @@ gradlew run
 ### Build Windows distribution
 In project folder, run:
 ```shell
-gradlew assembleDist
+gradlew jpackage
 ```
 
 ### Build Windows installer

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,6 @@ plugins {
     id 'org.gradlex.extra-java-module-info' version '1.3'
 }
 
-apply plugin: 'io.github.fvarrui.javapackager.plugin'
 apply plugin: 'com.gitlab.svg2ico'
 
 gitVersioning.apply {
@@ -174,11 +173,40 @@ sourceSets {
 jlink {
     options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages']
     launcher{
-        name = 'listfix'
-        noConsole = false
+        name = 'listFix()'
+        noConsole = true
         jvmArgs = ['-Dlog4j.configurationFile=./log4j2.xml']
     }
     forceMerge 'jackson', 'log4j', 'log4j-core', 'slf4j', 'com.jcabi.log'
+
+    jpackage {
+        jvmArgs = ['-splash:images/listfixSplashScreen.png']
+        def currentOs = org.gradle.internal.os.OperatingSystem.current()
+        icon = currentOs.windows ? pathFavicon : pathPngIcon
+        // version = project.version.findIndexOf('-') == -1 ? project.version : project.version.subString(0, project.version.findIndexOf('-'))
+        version = project.version.toString().replace("-", ".")
+        description = 'Fix and repairs broken playlist'
+        // imageOptions += ['--win-console']
+        installerOptions += [
+                '--vendor', project.vendor,
+                '--app-version', version,
+        ]
+        if (currentOs.windows) {
+            installerOptions += [
+                    '--win-upgrade-uuid', project.windowsUpgradeUuid,
+                    '--install-dir', 'listFix',
+                    '--win-per-user-install',
+                    '--win-dir-chooser',
+                    '--win-menu'
+            ]
+        } else if (currentOs.unix) {
+            installerOptions += [
+                    '--install-dir', '/opt/listfix',
+                    '--linux-package-name', 'listfix',
+                    '--linux-rpm-license-type', 'MIT'
+            ]
+        }
+    }
 }
 
 task fatJar(type: Jar) {
@@ -228,35 +256,14 @@ task makeIcon (type: Svg2IcoTask) {
     destination = file(pathFavicon)
 }
 
+tasks.processResources.dependsOn makeIcon
+
 tasks.withType(Checkstyle).configureEach {
     exclude 'listfix/model/playlists/winamp/generated/**.java'
 }
 
 task checkStyle(type: DefaultTask, dependsOn: [checkstyleMain, checkstyleTest]) {
     group = 'verification'
-}
-
-task packageMyApp(type: io.github.fvarrui.javapackager.gradle.PackageTask, dependsOn: [makeIcon, fatJar]) {
-    // mandatory
-    mainClass = project.mainClassName
-    runnableJar = file(fatJarFilePath)
-    // optional
-    bundleJre = true
-    generateInstaller = true
-    administratorRequired = false
-    platform = 'windows'
-    licenseFile = file('LICENSE.txt')
-    copyDependencies = false
-    customizedJre = false
-    winConfig {
-        headerType = 'gui'
-        icoFile = file(pathFavicon)
-    }
-    description = 'Repairs Missing Entries in Playlist Files'
-    organizationName = 'Borewit'
-    organizationUrl = 'https://github.com/Borewit'
-    url = 'https://github.com/Borewit/listFix'
-    additionalModules = ['jdk.incubator.foreign', 'jdk.incubator.jpackage']
 }
 
 tasks.withType(Test).configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+windowsUpgradeUuid = c8aa4be3-8977-4d3e-9de5-3e960c36954b
+vendor = Borewit

--- a/src/main/java/listfix/view/GUIScreen.java
+++ b/src/main/java/listfix/view/GUIScreen.java
@@ -93,7 +93,7 @@ public final class GUIScreen extends JFrame implements IListFixGui
   }
 
   public static String getBuildNumber() {
-    URL url = GUIScreen.class.getClassLoader().getResource("META-INF/MANIFEST.MF");
+    URL url = GUIScreen.class.getResource("/META-INF/MANIFEST.MF");
     try
     {
       Manifest manifest = new Manifest(url.openStream());


### PR DESCRIPTION
1. Build `.msi` & `.exe`, with jpackage,  and add these artifacts to the build pipeline
2. Remove the previous jlink runtime image artifact from the pipeline
3. Disabled the (DOS) console, (uses javaw instead of java)

Related to #164 

<a href="https://github.com/Borewit/listFix/actions/runs/4774069199/attempts/1#artifacts" title="Optional link title">
  <img alt="indows installers"
       title="Windows installers"
      width="600px"
       src="https://user-images.githubusercontent.com/23255260/233799889-5f6feb59-dcb2-4543-86fd-a7d57a7e1922.png"
  /></a>