### PR TITLE
Split comment and work process workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,8 @@
 name: CI
 
-# Trigger is on pull_request, to be able to generate a comment in the PR, linking the artifacts
-# Without this requirement, a more logic trigger would have been:
-# on: [push]
 on:
-  pull_request:
-    types: [synchronize]
+  workflow_call
+
 jobs:
   ubuntuBuild:
     name: Build deployment on Ubuntu
@@ -73,17 +70,3 @@ jobs:
         with:
           name: listFix-windows-exe
           path: build/jpackage/listFix()-*.exe
-  commentArtifacts:
-    name: Link build artifacts
-    runs-on: ubuntu-latest
-    needs:
-      - ubuntuBuild
-      - windowsBuild
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Comment PR linking artifact
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: |
-            [Build run (#${{ github.run_id }}, attempt #${{ github.run_attempt }}) artifacts](https://github.com/Borewit/listFix/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}#artifacts)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,21 @@
+name: Pull Request
+
+on:
+  pull_request:
+    types: [synchronize]
+
+jobs:
+  build:
+    uses: Borewit/listFix/.github/workflows/ci.yml@improve-ci
+  commentArtifacts:
+    name: Link build artifacts
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment PR linking artifact
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            [Build run (#${{ github.run_id }}, attempt #${{ github.run_attempt }}) artifacts](https://github.com/Borewit/listFix/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}#artifacts)

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,11 @@
+name: Push
+
+on:
+  push:
+    branches:
+      - 'main'
+jobs:
+  commentArtifacts:
+    name: Link build artifacts
+    runs-on: ubuntu-latest
+    uses: Borewit/listFix/.github/workflows/ci.yml@improve-ci


### PR DESCRIPTION
PR #166 introduced a PR message point to the artifacts.

Problem with that, is that the workflow event changed from [push](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push) to [pull_request](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), in order to get access to the PR. This works nicely within the PR, but the build process is now not triggered on the main branch.

I am going to try split the workflow in 2 parts. 
1. The main build process should by the [push](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push) event
2. Trigger a reporting work flow, which has PR access and reports the artifacts build by the first build process.

Note sure if this is possible. 