### PR TITLE
Fix repairing a selection of a playlist

### DIFF
--- a/src/main/java/listfix/model/playlists/Playlist.java
+++ b/src/main/java/listfix/model/playlists/Playlist.java
@@ -719,15 +719,14 @@ public class Playlist
     return findClosestMatches(entrySelection, libraryFiles, observer);
   }
 
-  public List<Integer> applyClosestMatchSelections(List<BatchMatchItem> items)
+  public List<PlaylistEntry> applyClosestMatchSelections(List<BatchMatchItem> items)
   {
-    List<Integer> fixed = new ArrayList<>();
+    List<PlaylistEntry> fixed = new ArrayList<>();
     for (BatchMatchItem item : items)
     {
       if (item.getSelectedIx() >= 0)
       {
-        int ix = item.getEntryIx();
-        PlaylistEntry playlistEntry = _entries.get(ix);
+        final PlaylistEntry playlistEntry = item.getEntry();
         if (playlistEntry instanceof FilePlaylistEntry)
         {
           ((FilePlaylistEntry) playlistEntry).update(item.getSelectedMatch().getTrack());
@@ -736,12 +735,11 @@ public class Playlist
         {
           throw new UnsupportedOperationException("ToDo");
         }
-        PlaylistEntry tempEntry = _entries.get(ix);
-        tempEntry.recheckFoundStatus();
-        tempEntry.markFixedIfFound();
-        if (tempEntry.isFixed())
+        playlistEntry.recheckFoundStatus();
+        playlistEntry.markFixedIfFound();
+        if (playlistEntry.isFixed())
         {
-          fixed.add(ix);
+          fixed.add(playlistEntry);
         }
       }
     }
@@ -1033,6 +1031,10 @@ public class Playlist
     }
     while (Files.exists(path));
     return path;
+  }
+
+  public int indexOf(PlaylistEntry playlistEntry) {
+    return this._entries.indexOf(playlistEntry);
   }
 
 }

--- a/src/main/java/listfix/view/controls/PlaylistEditCtrl.java
+++ b/src/main/java/listfix/view/controls/PlaylistEditCtrl.java
@@ -442,9 +442,10 @@ public class PlaylistEditCtrl extends JPanel
     if (dlg.isAccepted())
     {
       _uiTable.clearSelection();
-      List<Integer> fixed = _playlist.applyClosestMatchSelections(items);
-      for (Integer fixIx : fixed)
+      List<PlaylistEntry> fixed = _playlist.applyClosestMatchSelections(items);
+      for (PlaylistEntry fixEntry : fixed)
       {
+        int fixIx = _playlist.indexOf(fixEntry);
         int viewIx = _uiTable.convertRowIndexToView(fixIx);
         _uiTable.addRowSelectionInterval(viewIx, viewIx);
       }


### PR DESCRIPTION
Fixes the repair process, on a selection of playlist entries.
Result what written at the wrong location within the playlist. 

Resolves: Borewit/listFix#194, Borewit/listFix#196