### PR TITLE
Improve tablemodel notification repair playlist

### DIFF
--- a/src/main/java/listfix/model/BatchMatchItem.java
+++ b/src/main/java/listfix/model/BatchMatchItem.java
@@ -14,22 +14,15 @@ public class BatchMatchItem
   /**
    * Playlist position
    */
-  private final int _entryIx;
   private final PlaylistEntry _entry;
   private final List<PotentialPlaylistEntryMatch> matches;
   private PotentialPlaylistEntryMatch selectedMatch;
 
-  public BatchMatchItem(int ix, PlaylistEntry entry, List<PotentialPlaylistEntryMatch> matches)
+  public BatchMatchItem(PlaylistEntry entry, List<PotentialPlaylistEntryMatch> matches)
   {
-    this._entryIx = ix;
     this._entry = entry;
     this.matches = matches;
     this.selectedMatch = matches.size() > 0 ? matches.get(0) : null;
-  }
-
-  public int getEntryIx()
-  {
-    return this._entryIx;
   }
 
   public PlaylistEntry getEntry()

--- a/src/main/java/listfix/view/controls/PlaylistTableModel.java
+++ b/src/main/java/listfix/view/controls/PlaylistTableModel.java
@@ -1,0 +1,109 @@
+package listfix.view.controls;
+
+import listfix.model.playlists.Playlist;
+import listfix.model.playlists.PlaylistEntry;
+import listfix.view.support.ImageIcons;
+
+import javax.swing.*;
+import javax.swing.table.AbstractTableModel;
+
+class PlaylistTableModel extends AbstractTableModel
+{
+  private Playlist playlist;
+
+  PlaylistTableModel() {
+    this.playlist = null;
+  }
+
+  public void changePlaylist(Playlist playlist) {
+    this.playlist = playlist;
+    this.fireTableDataChanged();
+  }
+
+  @Override
+  public int getRowCount()
+  {
+    if (playlist != null)
+    {
+      return playlist.size();
+    }
+    else
+    {
+      return 0;
+    }
+  }
+
+  @Override
+  public int getColumnCount()
+  {
+    return 4;
+  }
+
+  @Override
+  public Object getValueAt(int rowIndex, int columnIndex)
+  {
+    PlaylistEntry entry = playlist.get(rowIndex);
+    switch (columnIndex)
+    {
+      case 0 ->
+      {
+        return rowIndex + 1;
+      }
+      case 1 ->
+      {
+        if (entry.isURL())
+        {
+          return ImageIcons.IMG_URL;
+        }
+        else if (entry.isFixed())
+        {
+          return ImageIcons.IMG_FIXED;
+        }
+        else if (entry.isFound())
+        {
+          return ImageIcons.IMG_FOUND;
+        }
+        else
+        {
+          return ImageIcons.IMG_MISSING;
+        }
+      }
+      case 2 ->
+      {
+        return entry.getTrackFileName();
+      }
+      case 3 ->
+      {
+        return entry.getTrackFolder();
+      }
+      default ->
+      {
+        return null;
+      }
+    }
+  }
+
+  @Override
+  public String getColumnName(int column)
+  {
+    return switch (column)
+      {
+        case 0 -> "#";
+        case 1 -> "";
+        case 2 -> "File Name";
+        case 3 -> "Location";
+        default -> null;
+      };
+  }
+
+  @Override
+  public Class<?> getColumnClass(int columnIndex)
+  {
+    return switch (columnIndex)
+      {
+        case 0 -> Integer.class;
+        case 1 -> ImageIcon.class;
+        default -> Object.class;
+      };
+  }
+}

--- a/src/main/java/listfix/view/controls/PlaylistsList.java
+++ b/src/main/java/listfix/view/controls/PlaylistsList.java
@@ -1,11 +1,3 @@
-
-
-/*
- * PlaylistsList.java
- *
- * Created on Apr 2, 2011, 12:11:40 PM
- */
-
 package listfix.view.controls;
 
 import listfix.model.BatchRepair;
@@ -26,7 +18,6 @@ import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.List;
 
-
 public class PlaylistsList extends JPanel
 {
   private BatchRepair _batch;
@@ -40,7 +31,6 @@ public class PlaylistsList extends JPanel
   {
     initComponents();
   }
-
 
   public PlaylistsList(BatchRepair batch)
   {


### PR DESCRIPTION
- Prevent background workers in the playlist-repair-process from calling [fireTableDataChanged()](https://docs.oracle.com/en/java/javase/11/docs/api/java.desktop/javax/swing/table/AbstractTableModel.html#fireTableDataChanged()) directly. This function should only be called by the GUI-Thread. This can prevent race conditions when repairing the playlist.
- Reduces the number of calls to update the table, when preceding call is pending, the repair mechanism continues
- Also refactored the code of the repair process a bit

Code changes:
- Moves `PlaylistTableModel.class` out of `PlaylistEditCtrl.class`, to it own file.

**Test criteria**
 Please review and merge #201 first, as that this one is put on top of that.

Expected difference:
1. The playlist table will updated less progressive
2. Repairs are performed slightly faster
3. Possible errors may now be prevented but that is very hard to test for. In following PR, #203, I will propose parallel processing, in that scenario weird errors are more likely to occur without his fix. 

