### PR TITLE
Parallel processing repairing playlist

### DIFF
--- a/src/main/java/listfix/model/playlists/Playlist.java
+++ b/src/main/java/listfix/model/playlists/Playlist.java
@@ -585,7 +585,7 @@ public class Playlist
 
     final long start = System.currentTimeMillis();
 
-    List<PlaylistEntry> fixed = _entries.stream().filter(entry -> {
+    List<PlaylistEntry> fixed = _entries.parallelStream().filter(entry -> {
       if (observer.getCancelled())
       {
         _logger.info(markerPlaylistRepair, "Observer cancelled, quit repair");

--- a/src/main/java/listfix/model/playlists/PlaylistEntry.java
+++ b/src/main/java/listfix/model/playlists/PlaylistEntry.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
-
 public abstract class PlaylistEntry implements Cloneable
 {
   // logger
@@ -126,8 +125,6 @@ public abstract class PlaylistEntry implements Cloneable
     List<PotentialPlaylistEntryMatch> matches = new ArrayList<>();
     ProgressAdapter<String> progress = new ProgressAdapter<>(observer);
     progress.setTotal(mediaFiles.size());
-
-    matches.clear();
 
     // Remove apostrophes and addAt spaces between lowercase and capital letters so we can tokenize by camel case.
     String entryName = CAMEL_CASE_PATTERN.matcher(APOS_PATTERN.matcher(getTrackFileName()).replaceAll("")).replaceAll("$2 $3").toLowerCase();

--- a/src/main/java/listfix/view/controls/PlaylistEditCtrl.java
+++ b/src/main/java/listfix/view/controls/PlaylistEditCtrl.java
@@ -306,7 +306,6 @@ public class PlaylistEditCtrl extends JPanel
     return !worker.isCancelled();
   }
 
-
   private void reorderList()
   {
     Playlist.SortIx sortIx = Playlist.SortIx.None;
@@ -807,7 +806,6 @@ public class PlaylistEditCtrl extends JPanel
     _uiTableScrollPane.setBorder(BorderFactory.createEtchedBorder());
 
     _uiTable.setAutoCreateRowSorter(true);
-
     _uiTable.setModel(playlistTableModel);
     _uiTable.setDragEnabled(true);
     _uiTable.setFillsViewportHeight(true);


### PR DESCRIPTION
Changed repair playlist to parallel process.
On a CPU with at least 3 cores, on lengthy playlists, this should reduce the total processing time.
The playlist is no longer fixed in perfect sequence.
