### PR TITLE
Extend version number with a short commit hash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ gitVersioning.apply {
             version = '${ref.version}'
         }
         branch('.+') {
-            version = '${describe.tag.version}-${describe.distance}'
+            version = '${describe.tag.version}-${describe.distance}-${commit.short}'
         }
     }
 
@@ -178,8 +178,7 @@ jlink {
         jvmArgs = ['-splash:images/listfixSplashScreen.png']
         def currentOs = org.gradle.internal.os.OperatingSystem.current()
         icon = currentOs.windows ? pathFavicon : pathPngIcon
-        // version = project.version.findIndexOf('-') == -1 ? project.version : project.version.subString(0, project.version.findIndexOf('-'))
-        version = project.version.toString().replace("-", ".")
+        version = project.version.toString().substring(0, project.version.toString().lastIndexOf("-") == -1 ? project.version.toString().length() : project.version.toString().lastIndexOf("-")).replace("-", ".")
         description = 'Fix and repairs broken playlist'
         // imageOptions += ['--win-console']
         installerOptions += [


### PR DESCRIPTION
Extend version number with a short commit hash in commits without a version tag.

The short commit hash is excluded from the Windows installer, as that only support decimal values separated with dots, with a maximum of 4 decimal values.

![image](https://github.com/Borewit/listFix/assets/23255260/26e554cf-8469-4268-8d66-a16521585d50)
