### PR TITLE
Update dependency Lizzy to 3.0.1, change M3U text encoding to ISO-8859-1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ repositories {
 dependencies {
 
     // Provides christophedelory.playlist.*
-    implementation 'io.github.borewit:lizzy:3.0.0'
+    implementation 'io.github.borewit:lizzy:3.0.1'
 
     // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core
     implementation 'org.apache.logging.log4j:log4j-core:2.20.0'

--- a/src/main/java/listfix/model/playlists/Playlist.java
+++ b/src/main/java/listfix/model/playlists/Playlist.java
@@ -985,7 +985,8 @@ public class Playlist
       OutputStream observableOutputStream = observer == null ? os : new ObservableOutputStream(os, currentFileSize, observer);
       try
       {
-        this.specificPlaylist.writeTo(observableOutputStream, null);
+        final String encoding = this.playlistPath.toString().toLowerCase().endsWith(".m3u8") ? "UTF-8" : null;
+        this.specificPlaylist.writeTo(observableOutputStream, encoding);
       }
       catch (Exception e)
       {


### PR DESCRIPTION
⚠️ Warning: may have issues reading M3U generated with previous versions as the encoding changed from [UTF-8](https://nl.wikipedia.org/wiki/UTF-8) to [ISO-8859-1](https://nl.wikipedia.org/wiki/ISO_8859-1).

Resolves #223 

Playlist previously saved as `.m3u` maybe causing character encoding issues. Best to rename those to `.m3u8` and load with liftFix() and save as `.m3u` if required. 
