### PR TITLE
Upload Windows binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
           java-version: 17
           distribution: corretto
           cache: gradle
+      - name: Git describe
+        id: ghd
+        uses: proudust/gh-describe@v1
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Build
@@ -36,7 +39,7 @@ jobs:
       - name: Upload fatJar artifact
         uses: actions/upload-artifact@v3
         with:
-          name: fatJar
+          name: fatJar-${{ steps.ghd.outputs.describe }}
           path: build/libs/listFix-*-all.jar
   windowsBuild:
     name: Build deployment on Windows
@@ -56,12 +59,20 @@ jobs:
           cache: gradle
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+      - name: Git describe
+        id: ghd
+        uses: proudust/gh-describe@v1
       - name: Build
         run: ./gradlew :build
       - name: Build Windows installers
         run: ./gradlew :jpackage
-      - name: Upload Windows exe
+      - name: Upload Windows exe installer
         uses: actions/upload-artifact@v3
         with:
-          name: listFix-windows-exe
+          name: listFix-windows-installer-exe-${{ steps.ghd.outputs.describe }}
           path: build/jpackage/listFix()-*.exe
+      - name: Upload Windows binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: listFix-windows-binaries-${{ steps.ghd.outputs.describe }}
+          path: build/jpackage/listFix()

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      # Only works on action triggered by pull_request
       - name: Comment PR linking artifact
         uses: thollander/actions-comment-pull-request@v2
         with:


### PR DESCRIPTION
Renames Windows installer artifact to: `listFix-windows-installer-exe-<build-number>`

Upload zipped binary artifact as: `listFix-windows-binaries-<build-number>`

Where _<build-number>_ is derived from [`git describe`](https://git-scm.com/docs/git-describe). For example: `v2.9.0-15-gcdfc83a`.
 
Resolves #240