### PR TITLE
Fix windows absolute path regression

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ task fatJar(type: Jar) {
 
 task makePngIcon(type: Svg2PngTask) {
     group = 'graphics'
-    source = file('src/main/svg/listFix() icon.svg')
+    source = new File('src/main/svg/listFix() icon.svg')
     width = 64
     height = 64
     destination = new File(pathPngIcon)

--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ task fatJar(type: Jar) {
 
 task makePngIcon(type: Svg2PngTask) {
     group = 'graphics'
-    source = new File('src/main/svg/listFix() icon.svg')
+    source = file('src/main/svg/listFix() icon.svg')
     width = 64
     height = 64
     destination = new File(pathPngIcon)

--- a/src/main/java/listfix/util/PathSanitizer.java
+++ b/src/main/java/listfix/util/PathSanitizer.java
@@ -24,7 +24,7 @@ public class PathSanitizer
       String part = parts[i];
 
       String sanitizedPart;
-      if (IS_WINDOWS && i == 0 && part.substring(0, 2).matches("^[A-Z]:$")) {
+      if (IS_WINDOWS && i == 0 && part.matches("^[a-zA-Z]:.*")) {
         sanitizedPart = part.substring(0, 2) + sanitizeWindowsPath(part.substring(2));
       }
       else {

--- a/src/main/java/listfix/util/PathSanitizer.java
+++ b/src/main/java/listfix/util/PathSanitizer.java
@@ -22,7 +22,14 @@ public class PathSanitizer
 
     for (int i = 0; i < parts.length; i++) {
       String part = parts[i];
-      String sanitizedPart = IS_WINDOWS ? sanitizeWindowsPath(part) : sanitizeUnixPath(part);
+
+      String sanitizedPart;
+      if (IS_WINDOWS && i == 0 && part.substring(0, 2).matches("^[A-Z]:$")) {
+        sanitizedPart = part.substring(0, 2) + sanitizeWindowsPath(part.substring(2));
+      }
+      else {
+          sanitizedPart = IS_WINDOWS ? sanitizeWindowsPath(part) : sanitizeUnixPath(part);
+      }
 
       if (i > 0) {
         sanitizedPath.append(File.separator);

--- a/src/test/java/listfix/util/PathSanitizerTests.java
+++ b/src/test/java/listfix/util/PathSanitizerTests.java
@@ -1,6 +1,7 @@
 package listfix.util;
 
 import java.nio.file.Path;
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,10 +17,18 @@ public class PathSanitizerTests
   {
 
     // Windows specific
-    Path path = PathSanitizer.makePath("..\\Dillon\\2011 - This Silence Kills\\03. Thirteen ? Thirtyfive.flac");
-    assertNotNull(path);
-    assertTrue(path.getFileName().toString().startsWith("03. Thirteen "));
-    assertNotNull(path.getParent(), "the file should have a parent path");
-    assertEquals(path.getParent().getFileName().toString(), "2011 - This Silence Kills");
+    List<String> pathStrings = List.of(
+                "..\\Dillon\\2011 - This Silence Kills\\03. Thirteen ? Thirtyfive.flac",    // Relative path
+                "D:\\Dillon\\2011 - This Silence Kills\\03. Thirteen ? Thirtyfive.flac",    // Absolute path
+                "D:Dillon\\2011 - This Silence Kills\\03. Thirteen ? Thirtyfive.flac"       // Relative path from the current directory of the D: drive
+    );
+
+    for (String pathStr : pathStrings) {
+        Path path = PathSanitizer.makePath(pathStr);
+        assertNotNull(path);
+        assertTrue(path.getFileName().toString().startsWith("03. Thirteen "));
+        assertNotNull(path.getParent(), "the file should have a parent path");
+        assertEquals(path.getParent().getFileName().toString(), "2011 - This Silence Kills");
+    }
   }
 }

--- a/src/test/java/listfix/util/PathSanitizerTests.java
+++ b/src/test/java/listfix/util/PathSanitizerTests.java
@@ -1,7 +1,6 @@
 package listfix.util;
 
-import java.nio.file.Path;
-import java.util.List;
+import java.io.File;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,18 +16,14 @@ public class PathSanitizerTests
   {
 
     // Windows specific
-    List<String> pathStrings = List.of(
-                "..\\Dillon\\2011 - This Silence Kills\\03. Thirteen ? Thirtyfive.flac",    // Relative path
-                "D:\\Dillon\\2011 - This Silence Kills\\03. Thirteen ? Thirtyfive.flac",    // Absolute path
-                "D:Dillon\\2011 - This Silence Kills\\03. Thirteen ? Thirtyfive.flac"       // Relative path from the current directory of the D: drive
-    );
-
-    for (String pathStr : pathStrings) {
-        Path path = PathSanitizer.makePath(pathStr);
-        assertNotNull(path);
-        assertTrue(path.getFileName().toString().startsWith("03. Thirteen "));
-        assertNotNull(path.getParent(), "the file should have a parent path");
-        assertEquals(path.getParent().getFileName().toString(), "2011 - This Silence Kills");
+    boolean isWindows = File.separatorChar == '\\';
+    if (isWindows) {
+      assertEquals("..\\Dillon\\2011 - This Silence Kills\\03. Thirteen _ Thirtyfive.flac", PathSanitizer.makePath("..\\Dillon\\2011 - This Silence Kills\\03. Thirteen ? Thirtyfive.flac").toString());
+      assertEquals(".\\Dillon\\2011 - This Silence Kills\\03. Thirteen _ Thirtyfive.flac", PathSanitizer.makePath(".\\Dillon\\2011 - This Silence Kills\\03. Thirteen ? Thirtyfive.flac").toString());
+      assertEquals("\\Dillon\\2011 - This Silence Kills\\03. Thirteen _ Thirtyfive.flac", PathSanitizer.makePath("\\Dillon\\2011 - This Silence Kills\\03. Thirteen ? Thirtyfive.flac").toString());
+      assertEquals("Dillon\\2011 - This Silence Kills\\03. Thirteen _ Thirtyfive.flac", PathSanitizer.makePath("Dillon\\2011 - This Silence Kills\\03. Thirteen ? Thirtyfive.flac").toString());
+      assertEquals("D:\\Dillon\\2011 - This Silence Kills\\03. Thirteen _ Thirtyfive.flac", PathSanitizer.makePath("D:\\Dillon\\2011 - This Silence Kills\\03. Thirteen ? Thirtyfive.flac").toString());
+      assertEquals("D:Dillon\\2011 - This Silence Kills\\03. Thirteen _ Thirtyfive.flac", PathSanitizer.makePath("D:Dillon\\2011 - This Silence Kills\\03. Thirteen ? Thirtyfive.flac").toString());
     }
   }
 }


### PR DESCRIPTION
Hello,
me again after doing lizzy pull request. :)

I tried to build listFix myself and discovered regression with latest update that I didn't use in the meantime. PathSanitizer removes ":" from Windows absolute paths.

Made a new branch this time, hope it's good.